### PR TITLE
Abstract away the version of the installation by putting the editor directly in the unity path

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,5 +21,5 @@ RUN apt-get -q update \
     lsb-release \
     && apt-get clean
 
-# Environment
-ENV UNITY_DIR="/opt/unity"
+# Used by Unity editor in "modules.json" and must not end with a slash.
+ENV UNITY_PATH="/opt/unity"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,25 +1,25 @@
 FROM ubuntu:20.04
 
 RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends apt-utils \
-    && apt-get -q install -y --no-install-recommends --allow-downgrades \
-    ca-certificates \
-    wget \
-    libxtst6 \
-    libxss1 \
-    desktop-file-utils \
-    libasound2 \
-    libgtk2.0-0 \
-    libnss3 \
-    xdg-utils \
-    xvfb \
-    zenity \
-    libdbus-glib-1-2 \
-    curl \
-    xz-utils \
-    cpio \
-    lsb-release \
-    && apt-get clean
+ && apt-get -q install -y --no-install-recommends apt-utils \
+ && apt-get -q install -y --no-install-recommends --allow-downgrades \
+ ca-certificates \
+ wget \
+ libxtst6 \
+ libxss1 \
+ desktop-file-utils \
+ libasound2 \
+ libgtk2.0-0 \
+ libnss3 \
+ xdg-utils \
+ xvfb \
+ zenity \
+ libdbus-glib-1-2 \
+ curl \
+ xz-utils \
+ cpio \
+ lsb-release \
+ && apt-get clean
 
 # Used by Unity editor in "modules.json" and must not end with a slash.
 ENV UNITY_PATH="/opt/unity"

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -22,4 +22,4 @@ FROM base
 
 ARG version="2020.1.4f1"
 
-COPY --from=builder /opt/unity/editors/ /opt/unity/
+COPY --from=builder /opt/unity/editors/$version/ /opt/unity/editor/

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -22,4 +22,13 @@ FROM base
 
 ARG version="2020.1.4f1"
 
-COPY --from=builder /opt/unity/editors/$version/ /opt/unity/editor/
+# Always put "Editor" and "modules.json" directly in $UNITY_PATH
+COPY --from=builder /opt/unity/editors/$version/ "$UNITY_PATH/"
+
+# Add a file containing the version for this build
+RUN echo $version > "$UNITY_PATH/version"
+
+# Alias to "editor" or "unity" with default params
+RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' > /usr/bin/editor \
+    && chmod +x /usr/bin/editor
+    && ln -s /usr/bin/editor /usr/bin/unity

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -30,5 +30,5 @@ RUN echo $version > "$UNITY_PATH/version"
 
 # Alias to "editor" or "unity" with default params
 RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' > /usr/bin/editor \
-    && chmod +x /usr/bin/editor \
-    && ln -s /usr/bin/editor /usr/bin/unity
+ && chmod +x /usr/bin/editor \
+ && ln -s /usr/bin/editor /usr/bin/unity

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -30,5 +30,5 @@ RUN echo $version > "$UNITY_PATH/version"
 
 # Alias to "editor" or "unity" with default params
 RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' > /usr/bin/editor \
-    && chmod +x /usr/bin/editor
+    && chmod +x /usr/bin/editor \
     && ln -s /usr/bin/editor /usr/bin/unity

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -7,7 +7,7 @@ RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3
     && /tmp/UnityHub.AppImage --appimage-extract \
     && cp -R /tmp/squashfs-root/* / \
     && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
-    && mkdir -p "$UNITY_DIR" \
+    && mkdir -p "$UNITY_PATH" \
     && mv /AppRun /opt/unity/UnityHub
 
 # Alias to "unity-hub" or simply "hub" with default params
@@ -19,4 +19,4 @@ RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox
 RUN mkdir -p "/root/.config/Unity Hub" && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
-RUN mkdir -p "${UNITY_DIR}/editors" && unity-hub install-path --set "${UNITY_DIR}/editors/" && find /tmp -mindepth 1 -delete
+RUN mkdir -p "${UNITY_PATH}/editors" && unity-hub install-path --set "${UNITY_PATH}/editors/" && find /tmp -mindepth 1 -delete

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -2,21 +2,24 @@ FROM base
 
 # Download & extract AppImage
 RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
-    && chmod +x /tmp/UnityHub.AppImage \
-    && cd /tmp \
-    && /tmp/UnityHub.AppImage --appimage-extract \
-    && cp -R /tmp/squashfs-root/* / \
-    && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
-    && mkdir -p "$UNITY_PATH" \
-    && mv /AppRun /opt/unity/UnityHub
+ && chmod +x /tmp/UnityHub.AppImage \
+ && cd /tmp \
+ && /tmp/UnityHub.AppImage --appimage-extract \
+ && cp -R /tmp/squashfs-root/* / \
+ && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
+ && mkdir -p "$UNITY_PATH" \
+ && mv /AppRun /opt/unity/UnityHub
 
 # Alias to "unity-hub" or simply "hub" with default params
 RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
-    && chmod +x /usr/bin/unity-hub \
-    && ln -s /usr/bin/unity-hub /usr/bin/hub
+ && chmod +x /usr/bin/unity-hub \
+ && ln -s /usr/bin/unity-hub /usr/bin/hub
 
 # Accept
-RUN mkdir -p "/root/.config/Unity Hub" && touch "/root/.config/Unity Hub/eulaAccepted"
+RUN mkdir -p "/root/.config/Unity Hub"
+ && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
-RUN mkdir -p "${UNITY_PATH}/editors" && unity-hub install-path --set "${UNITY_PATH}/editors/" && find /tmp -mindepth 1 -delete
+RUN mkdir -p "${UNITY_PATH}/editors"
+ && unity-hub install-path --set "${UNITY_PATH}/editors/"
+ && find /tmp -mindepth 1 -delete


### PR DESCRIPTION
- Convert UNITY_DIR to UNITY_PATH
- Abstract away the version of the installation by putting the editor directly in the unity path.
- Also add a file that contains the version in that same path.
- Move to 1 space, so that the output from docker runs is showing up properly