### PR TITLE
Added  libgconf-2-4

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -q update \
  xz-utils \
  cpio \
  lsb-release \
+ libgconf-2-4 \
  && apt-get clean
 
 # Support forward compatibility for unity activation


### PR DESCRIPTION
#### Changes

- Added libgconf-2-4 that was needed

#### Notes

Fixing `/opt/unity/Editor/Unity: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory`  error. 