### PR TITLE
Create retry workflow

### DIFF
--- a/.github/workflows/new-editor-image-requested.yml
+++ b/.github/workflows/new-editor-image-requested.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   buildImage:
-    name: "🛠 Build unityci/editor (${{ matrix.targetPlatform}})"
+    name: "🛠 Build unityci/editor (${{ matrix.targetPlatform }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -69,7 +69,7 @@ jobs:
             curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
           }
 
-          if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionFull }} ; then
+          if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
             exit 1
           fi
@@ -77,9 +77,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-
+            ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-
             ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-
             ${{ runner.os }}-buildx-editor-
             ${{ runner.os }}-buildx-
@@ -114,16 +114,16 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           push: true
           tags: |
-            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionFull }}
-            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionFull }}
-            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionMinor }}
-            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionMinor }}
-            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionMajor }}
-            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
       - name: Inspect
         run: |
-          docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform}}-${{ github.event.client_payload.repoVersionFull }}
+          docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
       - name: Image digest
         run: echo ${{ steps.build_editor_image.outputs.digest }}
       - name: Update DockerHub description

--- a/.github/workflows/retry-editor-image-requested.yml
+++ b/.github/workflows/retry-editor-image-requested.yml
@@ -1,0 +1,169 @@
+name: Retry Building Editor Version 🗔
+
+on:
+  repository_dispatch:
+    types: [retry_editor_image_requested]
+
+# Further reading:
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+# https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#create-a-repository-dispatch-event
+# https://developer.github.com/webhooks/event-payloads/#repository_dispatch
+
+jobs:
+  buildImage:
+    name: "🛠 Retry unityci/editor (${{ github.event.client_payload.targetPlatform }})"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      ###########################
+      #        Variables        #
+      ###########################
+      - name: Show hook input
+        run: |
+          echo "Event ${{ github.event.event_type }}"
+          echo "jobId: ${{ github.event.client_payload.jobId }}"
+          echo "Target platform to retry: ${{ github.event.client_payload.targetPlatform }}"
+          echo "Unity editor version: ${{ github.event.client_payload.editorVersion }}"
+          echo "Unity changeset: ${{ github.event.client_payload.changeSet }}"
+          echo "repoVersion (full): ${{ github.event.client_payload.repoVersionFull }}"
+          echo "repoVersion (only minor and major): ${{ github.event.client_payload.repoVersionMinor }}"
+          echo "repoVersion (only major): ${{ github.event.client_payload.repoVersionMajor }}"
+      - name: Report new build
+        uses: ./.github/workflows/actions/report-to-backend
+        with:
+          token: ${{ secrets.VERSIONING_TOKEN }}
+          jobId: ${{ github.event.client_payload.jobId }}
+          status: started
+          # Build info
+          imageType: editor
+          baseOs: ubuntu
+          repoVersion: ${{ github.event.client_payload.repoVersionFull }}
+          editorVersion: ${{ github.event.client_payload.editorVersion }}
+          targetPlatform: ${{ github.event.client_payload.targetPlatform }}
+      ###########################
+      #          Setup          #
+      ###########################
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Check if image not already exists
+        run: |
+          # Source: https://stackoverflow.com/a/39731444/3593896
+          function docker_tag_exists() {
+            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+          }
+
+          if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then
+            echo "Image already exists. Exiting."
+            exit 1
+          fi
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-
+            ${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-
+            ${{ runner.os }}-buildx-editor-
+            ${{ runner.os }}-buildx-
+      ###########################
+      #    Free disk space   #
+      ###########################
+      - name: Free disk space
+        run: .github/workflows/scripts/free_disk_space.sh
+      ###########################
+      #   Pull previous images  #
+      ###########################
+      - name: Pull base image (must exist)
+        run: docker pull unityci/base:${{ github.event.client_payload.repoVersionFull }}
+      - name: Pull hub image (must exist)
+        run: docker pull unityci/hub:${{ github.event.client_payload.repoVersionFull }}
+      ###########################
+      #       Editor image      #
+      ###########################
+      - name: Build and publish
+        uses: docker/build-push-action@v2
+        id: build_editor_image
+        with:
+          context: .
+          file: ./editor/Dockerfile
+          build-args: |
+            hubImage=unityci/hub:${{ github.event.client_payload.repoVersionFull }}
+            baseImage=unityci/base:${{ github.event.client_payload.repoVersionFull }}
+            version=${{ github.event.client_payload.editorVersion }}
+            changeSet=${{ github.event.client_payload.changeSet }}
+            module=${{ github.event.client_payload.targetPlatform }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          push: true
+          tags: |
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+          ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+      - name: Image digest
+        run: echo ${{ steps.build_editor_image.outputs.digest }}
+      - name: Update DockerHub description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: unityci/editor
+          short-description: $(cat ./editor/100-characters-dockerhub-description.txt)
+          readme-filepath: ./editor/README.md
+      ###########################
+      #        reporting        #
+      ###########################
+      - name: Report publication
+        if: ${{ success() }}
+        uses: ./.github/workflows/actions/report-to-backend
+        with:
+          token: ${{ secrets.VERSIONING_TOKEN }}
+          jobId: ${{ github.event.client_payload.jobId }}
+          status: published
+          # Build info
+          imageType: editor
+          baseOs: ubuntu
+          repoVersion: ${{ github.event.client_payload.repoVersionFull }}
+          editorVersion: ${{ github.event.client_payload.editorVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          # Publication info
+          imageRepo: unityci
+          imageName: editor
+          friendlyTag: ${{ github.event.client_payload.repoVersionMinor }}
+          specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
+          digest: ${{ steps.build_editor_image.outputs.digest }}
+      - name: Report failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/workflows/actions/report-to-backend
+        with:
+          token: ${{ secrets.VERSIONING_TOKEN }}
+          jobId: ${{ github.event.client_payload.jobId }}
+          status: failed
+          # Build info
+          imageType: editor
+          baseOs: ubuntu
+          repoVersion: ${{ github.event.client_payload.repoVersionFull }}
+          editorVersion: ${{ github.event.client_payload.editorVersion }}
+          targetPlatform: repository_dispatch
+          # Failure info
+          reason: ${{ job.status }}
+      ###########################
+      #         Metrics         #
+      ###########################
+      - name: Disk space after
+        if: always()
+        run: df -h


### PR DESCRIPTION
#### Changes

- This adds the retry workflow, which allows the versioning backend to reschedule builds for single `targetPlatforms`. 

Context: The versioning backend doesn't know all possible targetPlatforms, but it knows which ones to retry by simply checking the reported failures (which include information about the targetPlatform).

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
