### PR TITLE
Update readme

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -15,7 +15,7 @@ docker run -it --rm unity-ci/editor bash
 Run the editor 
 
 ```bash
-unity help
+unity-editor help
 ```
 
 ## License

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -16,10 +16,9 @@ RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3
  && mkdir -p "$UNITY_PATH" \
  && mv /AppRun /opt/unity/UnityHub
 
-# Alias to "unity-hub" or simply "hub" with default params
+# Alias to "unity-hub" with default params
 RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
- && chmod +x /usr/bin/unity-hub \
- && ln -s /usr/bin/unity-hub /usr/bin/hub
+ && chmod +x /usr/bin/unity-hub
 
 # Accept
 RUN mkdir -p "/root/.config/Unity Hub" \


### PR DESCRIPTION
#### Changes

- Updates readme that reflects the change from `editor` and `unity` binaries to `unity-editor` binaries, so that it no longer conflicts with text editors.

This as `editor` is already used by Ubuntu as an alias to the default text editor. E.g. if you `apt-get install vim` you'll have a symlink `/usr/bin/editor` -> `/etc/alternatives/editor`

Our solution is to simply be more specific about our binary name.

- This also reflects the same change for hub, by removing the shorthand `hub` variety.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
