### PR TITLE
Add missing libdl.so using burst compiler

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,9 +6,11 @@ RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \
  ca-certificates \
  libasound2 \
+ libc6-dev \
  libgconf-2-4 \
  libglu1 \
  libgtk-3-0 \
+ libncurses5 \
  libnss3 \
  libxtst6 \
  libxss1 \


### PR DESCRIPTION
#### Changes

- Add dependency for burst compiler
- Fixes: https://github.com/webbertakken/unity-builder/issues/175

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
