### PR TITLE
Change to ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ To contribute, please see the [development readme](./DEVELOPMENT.md)
 after you agree with our [code of conduct](./CODE_OF_CONDUCT.md) 
 and have read the [contribution guide](./CONTRIBUTING.md).
 
-## Todo
-
-Move these deps from base to hub image if possible
-
-- xz-utils 
-- cpio
-- lsb-release
-
 ## License
 
 [MIT license](./LICENSE)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get -q update \
  wget \
  && apt-get clean
 
+# Disable default sound card, which removes ALSA warnings
+ADD config/asound.conf /etc/
+
 # Support forward compatibility for unity activation
 RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && mkdir -p /var/lib/dbus/ && ln -sf /etc/machine-id /var/lib/dbus/machine-id
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 # Global dependencies
 RUN apt-get -q update \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -q update \
  && apt-get clean
 
 # Support forward compatibility for unity activation
-RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && ln -sf /etc/machine-id /var/lib/dbus/machine-id
+RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && mkdir -p /var/lib/dbus/ && ln -sf /etc/machine-id /var/lib/dbus/machine-id
 
 # Used by Unity editor in "modules.json" and must not end with a slash.
 ENV UNITY_PATH="/opt/unity"

--- a/config/asound.conf
+++ b/config/asound.conf
@@ -1,0 +1,4 @@
+pcm.!default {
+    type plug
+    slave.pcm "null"
+}


### PR DESCRIPTION
#### Changes

- This changes the ubuntu images back from 20 LTS to 18 LTS, which solves a nuanced issue with libasound2 and makes our images go back to the officially supported OSes range.
- Disable the default sound card, to silence any residual warnings.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
