### PR TITLE
Install Git LFS

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get -q update \
  wget \
  && apt-get clean
 
+# Install Git LFS
+RUN git lfs install --system --skip-repo
+
 # Disable default sound card, which removes ALSA warnings
 ADD config/asound.conf /etc/
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -28,10 +28,8 @@ RUN apt-get -q update \
  git \
  git-lfs \
  wget \
+ && git lfs install --system --skip-repo \
  && apt-get clean
-
-# Install Git LFS
-RUN git lfs install --system --skip-repo
 
 # Disable default sound card, which removes ALSA warnings
 ADD config/asound.conf /etc/


### PR DESCRIPTION
#### Changes

Added installing of Git LFS systemwide. Ubuntu 18's git-lfs is (version 2.3.4-1) is not installed by default after installing the apt package and manual installation is required. Note that an error message is emitted during installation, but it's harmless, see this issue: https://github.com/git-lfs/git-lfs/issues/3013

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)
